### PR TITLE
fix: apply cargo fmt and fix critical clippy warnings

### DIFF
--- a/src/archive_threads.rs
+++ b/src/archive_threads.rs
@@ -10,8 +10,11 @@ pub async fn archive_locked_threads() -> Result<()> {
 
     // Load configuration
     let config = Config::load()?;
-    
-    println!("Thread prefixes to check: {:?}", crate::constants::THREAD_PREFIXES);
+
+    println!(
+        "Thread prefixes to check: {:?}",
+        crate::constants::THREAD_PREFIXES
+    );
     println!();
 
     // Use shared clients
@@ -20,10 +23,14 @@ pub async fn archive_locked_threads() -> Result<()> {
 
     // Process each project
     for (idx, project) in config.projects.iter().enumerate() {
-        println!("Project {}: {}", idx + 1, project.name.as_deref().unwrap_or("unnamed"));
+        println!(
+            "Project {}: {}",
+            idx + 1,
+            project.name.as_deref().unwrap_or("unnamed")
+        );
         println!("  - Discord Guild: {}", project.discord_guild_id);
         println!("  - Discord Forum: {}", project.discord_forum_id);
-        
+
         match archive_project_threads(&discord, project).await {
             Ok(count) => {
                 println!("  ✅ Archived {} locked threads", count);
@@ -57,9 +64,10 @@ async fn archive_project_threads(
 
         // Check if thread has valid prefix
         let thread_name = &thread.name;
-        let has_valid_prefix = crate::constants::THREAD_PREFIXES.iter()
+        let has_valid_prefix = crate::constants::THREAD_PREFIXES
+            .iter()
             .any(|prefix| thread_name.starts_with(prefix));
-        
+
         if !has_valid_prefix {
             continue;
         }
@@ -70,12 +78,15 @@ async fn archive_project_threads(
         let is_archived = metadata.map(|m| m.archived).unwrap_or(false);
 
         if is_locked && !is_archived {
-            println!("  - Archiving locked thread: {} ({})", thread_name, thread.id);
-            
+            println!(
+                "  - Archiving locked thread: {} ({})",
+                thread_name, thread.id
+            );
+
             // Archive the thread
-            thread.id
-                .edit_thread(discord, serenity::builder::EditThread::new()
-                    .archived(true))
+            thread
+                .id
+                .edit_thread(discord, serenity::builder::EditThread::new().archived(true))
                 .await?;
 
             archived_count += 1;

--- a/src/audit_sync.rs
+++ b/src/audit_sync.rs
@@ -13,10 +13,13 @@ pub async fn audit_sync_status() -> Result<()> {
     // Load configuration
     let config = Config::load()?;
     let sync_config = config.sync_config();
-    
+
     println!("Sync Configuration:");
     println!("  - Enabled: {}", sync_config.enabled);
-    println!("  - Thread prefixes: {:?}", crate::constants::THREAD_PREFIXES);
+    println!(
+        "  - Thread prefixes: {:?}",
+        crate::constants::THREAD_PREFIXES
+    );
     println!();
 
     // Use shared clients
@@ -26,14 +29,21 @@ pub async fn audit_sync_status() -> Result<()> {
 
     // Audit each project
     for (idx, project) in config.projects.iter().enumerate() {
-        println!("Project {}: {}", idx + 1, project.name.as_deref().unwrap_or("unnamed"));
-        println!("  - GitHub: {}/{}", project.github_owner, project.github_repo);
+        println!(
+            "Project {}: {}",
+            idx + 1,
+            project.name.as_deref().unwrap_or("unnamed")
+        );
+        println!(
+            "  - GitHub: {}/{}",
+            project.github_owner, project.github_repo
+        );
         println!("  - Discord Guild: {}", project.discord_guild_id);
         println!("  - Discord Forum: {}", project.discord_forum_id);
         println!();
-        
+
         match audit_project(&github, &discord, project).await {
-            Ok(()) => {},
+            Ok(()) => {}
             Err(e) => {
                 eprintln!("  ❌ Error auditing project: {}", e);
             }
@@ -54,53 +64,61 @@ async fn audit_project(
         "repo:{}/{} is:open in:title",
         project.github_owner, project.github_repo
     );
-    
+
     let search_result = github
         .search()
         .issues_and_pull_requests(&query)
         .send()
         .await?;
-    
+
     // Build set of open issue thread IDs
-    let github_open_threads: HashSet<u64> = search_result.items
+    let github_open_threads: HashSet<u64> = search_result
+        .items
         .iter()
         .filter_map(|issue| extract_thread_id(&issue.title))
         .collect();
-    
+
     println!("  📊 GitHub Status:");
-    println!("    - Open issues with thread IDs: {}", github_open_threads.len());
-    
+    println!(
+        "    - Open issues with thread IDs: {}",
+        github_open_threads.len()
+    );
+
     // Get Discord threads
     let guild_id = GuildId::new(project.discord_guild_id.parse()?);
     let forum_id = ChannelId::new(project.discord_forum_id.parse()?);
     let active_threads = guild_id.get_active_threads(discord).await?;
-    
+
     // Analyze managed threads
     let mut discord_managed_unlocked = 0;
     let mut discord_managed_locked = 0;
     let mut threads_with_wrong_state = Vec::new();
     let mut existing_thread_ids = HashSet::new();
-    
+
     for thread in active_threads.threads {
         // Only process threads in our forum
         if thread.parent_id != Some(forum_id) {
             continue;
         }
-        
+
         let thread_id = thread.id.get();
-        
+
         // Only care about threads that are managed (have their ID in a GitHub issue)
         if github_open_threads.contains(&thread_id) {
             existing_thread_ids.insert(thread_id);
-            
+
             // This thread is linked to an open GitHub issue
             let metadata = thread.thread_metadata.as_ref();
             let is_locked = metadata.map(|m| m.locked).unwrap_or(false);
             let is_archived = metadata.map(|m| m.archived).unwrap_or(false);
-            
+
             if !is_archived {
                 if is_locked {
-                    threads_with_wrong_state.push((thread_id, thread.name.clone(), "Should be UNLOCKED (issue is open)"));
+                    threads_with_wrong_state.push((
+                        thread_id,
+                        thread.name.clone(),
+                        "Should be UNLOCKED (issue is open)",
+                    ));
                     discord_managed_locked += 1;
                 } else {
                     discord_managed_unlocked += 1;
@@ -108,20 +126,23 @@ async fn audit_project(
             }
         }
     }
-    
+
     // Find issues without existing Discord threads
     let missing_threads: Vec<_> = github_open_threads
         .iter()
         .filter(|&&id| !existing_thread_ids.contains(&id))
         .collect();
-    
+
     println!("\n  💬 Discord Status:");
-    println!("    - Managed threads found: {}", discord_managed_unlocked + discord_managed_locked);
+    println!(
+        "    - Managed threads found: {}",
+        discord_managed_unlocked + discord_managed_locked
+    );
     println!("    - Correctly unlocked: {}", discord_managed_unlocked);
     println!("    - Incorrectly locked: {}", discord_managed_locked);
-    
+
     println!("\n  🔄 Sync Analysis:");
-    
+
     if threads_with_wrong_state.is_empty() && missing_threads.is_empty() {
         println!("    ✅ All managed threads are properly synced!");
     } else {
@@ -131,24 +152,31 @@ async fn audit_project(
                 println!("      - {} (ID: {}) - {}", name, id, reason);
             }
         }
-        
+
         if !missing_threads.is_empty() {
-            println!("\n    ℹ️  {} open GitHub issues reference missing Discord threads", missing_threads.len());
+            println!(
+                "\n    ℹ️  {} open GitHub issues reference missing Discord threads",
+                missing_threads.len()
+            );
             println!("    (These threads may have been deleted or archived)");
             if missing_threads.len() <= 5 {
                 for &&thread_id in &missing_threads {
-                    if let Some(issue) = search_result.items.iter().find(|i| extract_thread_id(&i.title) == Some(thread_id)) {
+                    if let Some(issue) = search_result
+                        .items
+                        .iter()
+                        .find(|i| extract_thread_id(&i.title) == Some(thread_id))
+                    {
                         println!("      - Issue #{}: {}", issue.number, issue.title);
                     }
                 }
             }
         }
     }
-    
+
     println!("\n  📝 Summary:");
     println!("    - Sync only manages threads where CardiBot created a GitHub issue");
     println!("    - Other Discord threads (even with [BUG] prefix) are ignored");
     println!("    - Threads are identified as managed by checking for bot messages");
-    
+
     Ok(())
 }

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -14,18 +14,18 @@ impl Clients {
     pub async fn new_standalone() -> Result<Self> {
         // Ensure environment variables are loaded
         dotenv::dotenv().ok();
-        
+
         let github = Arc::new(crate::github_app::create_github_client().await?);
-        
+
         let discord_token = std::env::var("DISCORD_TOKEN")?;
         let discord_http = Arc::new(Http::new(&discord_token));
-        
+
         Ok(Self {
             github,
             discord_http,
         })
     }
-    
+
     /// Create clients from existing instances (for use in main bot)
     pub fn from_existing(github: Arc<Octocrab>, discord_http: Arc<Http>) -> Self {
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,6 @@ fn default_sync_interval() -> u64 {
     10
 }
 
-
 #[derive(Debug, Deserialize, Clone)]
 pub struct Project {
     pub name: Option<String>,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,4 @@
 /// Constants used throughout the CardiBot application
-
 // Discord embed colors
 pub const COLOR_SUCCESS: u32 = 0x238636; // Green
 
@@ -16,7 +15,7 @@ pub const PREFIX_FEEDBACK: &str = "[FEEDBACK]";
 
 // GitHub labels (as used in the API)
 pub const LABEL_BUG: &str = "bug";
-pub const LABEL_FEATURE: &str = "enhancement";  
+pub const LABEL_FEATURE: &str = "enhancement";
 pub const LABEL_QUESTION: &str = "question";
 pub const LABEL_FEEDBACK: &str = "feedback";
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -109,7 +109,6 @@ pub async fn check_discord() -> anyhow::Result<()> {
 }
 
 pub async fn post_feedback_instructions(channel_id: &str) -> anyhow::Result<()> {
-
     let channel_id = ChannelId::new(channel_id.parse::<u64>()?);
 
     // Use shared clients

--- a/src/github.rs
+++ b/src/github.rs
@@ -104,7 +104,12 @@ pub async fn extract_thread_content(
     ctx: &serenity::prelude::Context,
     thread: &GuildChannel,
 ) -> Result<String> {
-    let messages = thread.messages(&ctx, GetMessages::new().limit(crate::constants::GITHUB_THREAD_CONTENT_LIMIT)).await?;
+    let messages = thread
+        .messages(
+            &ctx,
+            GetMessages::new().limit(crate::constants::GITHUB_THREAD_CONTENT_LIMIT),
+        )
+        .await?;
 
     let content = messages
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,14 @@ async fn main() -> Result<()> {
             // Initialize logging with configured level
             let log_level = config.log_level.as_deref().unwrap_or("info");
             use tracing_subscriber::EnvFilter;
-            
+
             // Build filter to exclude octocrab and HTTP client deprecation warnings
-            let filter = EnvFilter::new(format!("{},octocrab=warn,reqwest=warn,hyper=warn", log_level));
-            
-            tracing_subscriber::fmt()
-                .with_env_filter(filter)
-                .init();
+            let filter = EnvFilter::new(format!(
+                "{},octocrab=warn,reqwest=warn,hyper=warn",
+                log_level
+            ));
+
+            tracing_subscriber::fmt().with_env_filter(filter).init();
 
             tracing::info!("Loaded {} projects", config.projects.len());
 
@@ -112,10 +113,8 @@ async fn main() -> Result<()> {
                 .await?;
 
             // Create shared clients for sync task
-            let shared_clients = clients::Clients::from_existing(
-                github.clone(),
-                client.http.clone(),
-            );
+            let shared_clients =
+                clients::Clients::from_existing(github.clone(), client.http.clone());
 
             // Spawn sync task if enabled
             let sync_config_clone = config.clone();


### PR DESCRIPTION
## Summary
- Applied cargo fmt to all Rust files to fix CI formatting issues
- Fixed empty line after doc comment warning in constants.rs
- Removed unneeded return statement in sync.rs

## Test plan
- [x] Run `cargo fmt --check` - passes
- [x] Run `cargo check` - passes
- [x] Run `cargo clippy` - reduced warnings

🤖 Generated with [Claude Code](https://claude.ai/code)