### PR TITLE
fix: apply final cargo fmt changes

### DIFF
--- a/src/debug_sync.rs
+++ b/src/debug_sync.rs
@@ -96,10 +96,7 @@ async fn debug_project_sync(github: &Octocrab, project: &crate::config::Project)
         if let Some(thread_id) = extract_thread_id(&issue.title) {
             println!(
                 "    • Issue #{} [{}] - Thread ID: {} - State: {:?}",
-                issue.number,
-                issue.title,
-                thread_id,
-                issue.state
+                issue.number, issue.title, thread_id, issue.state
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,8 @@ async fn main() -> Result<()> {
             use tracing_subscriber::EnvFilter;
 
             // Build filter to exclude octocrab and HTTP client deprecation warnings
-            let filter = EnvFilter::new(format!(
-                "{log_level},octocrab=warn,reqwest=warn,hyper=warn"
-            ));
+            let filter =
+                EnvFilter::new(format!("{log_level},octocrab=warn,reqwest=warn,hyper=warn"));
 
             tracing_subscriber::fmt().with_env_filter(filter).init();
 


### PR DESCRIPTION
## Summary
Final formatting fixes to pass CI checks:
- Format multi-line println\! statement to single line in debug_sync.rs
- Format filter assignment to multi-line for readability in main.rs

## Test plan
- [x] Run `cargo fmt --check` - passes
- [x] Run `cargo clippy -- -D warnings` - passes
- [x] Run `cargo check` - passes

🤖 Generated with [Claude Code](https://claude.ai/code)