### PR TITLE
fix: implement GitHub App token refresh mechanism

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -25,12 +25,4 @@ impl Clients {
             discord_http,
         })
     }
-
-    /// Create clients from existing instances (for use in main bot)
-    pub fn from_existing(github: Arc<Octocrab>, discord_http: Arc<Http>) -> Self {
-        Self {
-            github,
-            discord_http,
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,18 +110,11 @@ async fn main() -> Result<()> {
                 .event_handler(bot)
                 .await?;
 
-            // Create shared clients for sync task
-            let shared_clients =
-                clients::Clients::from_existing(github.clone(), client.http.clone());
-
             // Spawn sync task if enabled
             let sync_config_clone = config.clone();
+            let discord_http_clone = client.http.clone();
             tokio::spawn(async move {
-                let syncer = sync::IssueSyncer::new(
-                    sync_config_clone,
-                    shared_clients.github,
-                    shared_clients.discord_http,
-                );
+                let syncer = sync::IssueSyncer::new(sync_config_clone, discord_http_clone);
                 syncer.start().await;
             });
 


### PR DESCRIPTION
## Summary
This PR fixes the "Bad credentials" error that occurs after ~1 hour when using GitHub App authentication.

## Problem
GitHub App installation tokens expire after 1 hour. The bot was creating the GitHub client once at startup and reusing it, so after an hour the token would expire and all API calls would fail with:
```
Error syncing project Levvy V3 Testnet: GitHub
Caused by:
    Bad credentials
    Documentation URL: https://docs.github.com/rest
```

## Solution
- Modified `IssueSyncer` to create a fresh GitHub client for each sync cycle
- Removed the stored GitHub client reference from the `IssueSyncer` struct
- Pass the GitHub client as a parameter to sync methods that need it
- Cleaned up unused `from_existing` method in `Clients` struct

Now each sync cycle (every 60 seconds) creates a new GitHub client with a fresh token, ensuring it never expires.

## Test plan
- [x] Run `cargo fmt --check` - passes
- [x] Run `cargo clippy -- -D warnings` - no warnings
- [x] Run `cargo test --verbose` - all tests pass
- [x] Run `cargo build --verbose` - builds successfully

## Testing with GitHub App
To test this fix:
1. Configure GitHub App credentials
2. Run the bot for more than 1 hour
3. Verify sync continues working without "Bad credentials" errors

🤖 Generated with [Claude Code](https://claude.ai/code)