### PR TITLE
fix: implement token refresh for slash commands and defer responses

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 pub struct Bot {
     pub config: Arc<crate::config::Config>,
-    pub github: Arc<octocrab::Octocrab>,
 }
 
 #[async_trait]
@@ -28,7 +27,9 @@ impl EventHandler for Bot {
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
         if let Interaction::Command(command) = interaction {
             if command.data.name.as_str() == "issue" {
-                if let Err(e) = crate::commands::handle_issue_command(&ctx, &command, self).await {
+                if let Err(e) =
+                    crate::commands::handle_issue_command(&ctx, &command, &self.config).await
+                {
                     tracing::error!("Error handling command: {:?}", e);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,6 @@ async fn main() -> Result<()> {
 
             tracing::info!("Loaded {} projects", config.projects.len());
 
-            // Initialize GitHub client (supports both App and PAT auth)
-            let github = Arc::new(github_app::create_github_client().await?);
-
             // Initialize Discord bot
             let discord_token = std::env::var("DISCORD_TOKEN")?;
             let intents = GatewayIntents::GUILDS
@@ -103,7 +100,6 @@ async fn main() -> Result<()> {
 
             let bot = bot::Bot {
                 config: config.clone(),
-                github: github.clone(),
             };
 
             let mut client = Client::builder(&discord_token, intents)


### PR DESCRIPTION
## Summary
This PR fixes two critical issues with the `/issue create` command:
1. **"Bad credentials" error** - The command was using an expired GitHub token
2. **"Unknown interaction" error** - Discord was timing out waiting for a response

## Problems Fixed

### 1. GitHub Token Expiration in Commands
The Bot struct was storing a GitHub client created at startup. After ~1 hour, the GitHub App token would expire causing:
```
ERROR cardibot::bot: Error handling command: GitHub
Caused by:
    Bad credentials
```

### 2. Discord Interaction Timeout
Creating a GitHub issue takes time (API calls, etc). Discord interactions have a 3-second timeout, causing:
```
ERROR cardibot::bot: Error handling command: Http(UnsuccessfulRequest(ErrorResponse { 
    status_code: 404, 
    error: DiscordJsonError { code: 10062, message: "Unknown interaction" }
}))
```

## Solution
1. **Token Refresh**: Remove stored GitHub client from Bot struct and create a fresh client for each command
2. **Defer Response**: Immediately defer the Discord interaction, then update it when ready

## Changes
- Removed `github` field from `Bot` struct
- Modified `handle_issue_command` to create fresh GitHub client
- Added deferred response at the start of command handling
- Changed all responses to use `edit_response` instead of `create_response`

## Test plan
- [x] Run `cargo fmt --check` - passes
- [x] Run `cargo clippy -- -D warnings` - no warnings
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo check` - compiles successfully

## Testing Instructions
1. Deploy this version
2. Wait >1 hour to ensure tokens would have expired
3. Use `/issue create` command - should work without authentication errors
4. Verify no "Unknown interaction" errors in logs

🤖 Generated with [Claude Code](https://claude.ai/code)